### PR TITLE
Fix wrong initialization of v

### DIFF
--- a/matrixslow/optimizer/optimizer.py
+++ b/matrixslow/optimizer/optimizer.py
@@ -160,7 +160,7 @@ class Momentum(Optimizer):
                 gradient = self.get_gradient(node)
 
                 if node not in self.v:
-                    self.v[node] = gradient
+                    self.v[node] = - self.learning_rate * gradient
                 else:
                     # 滑动平均累积历史速度
                     self.v[node] = self.momentum * self.v[node] \


### PR DESCRIPTION
发现一个小 bug，鉴于这里的 v 是直接用来更新参数的（而不是 v 乘上学习率后再用来更新），第一次执行 Momentum 的 _update() 的时候，用来初始化 v[node] 的值也应该乘上学习率。
运行一下 example/ch03/optimizer_example.py 也可以发现（改成用 Momentum 优化器）：不改的话前几个 epoch 准确率一直很低，而改过之后准确率显著提高