### PR TITLE
Use ceil instead of floor to partition jobs

### DIFF
--- a/matrixslow/trainer/dist_trainer.py
+++ b/matrixslow/trainer/dist_trainer.py
@@ -4,6 +4,7 @@ Created on Thu Jul 18 20:48:16 CST 2019
 
 @author: chenzhen
 """
+import math
 import threading
 import time
 
@@ -172,7 +173,7 @@ class DistTrainerRingAllReduce(Trainer):
         根据worker的总数量，对即将更新的权值变量列表进行等长切分
         '''
         var_num = len(self.variables)
-        part_length = int(var_num / self.worker_num)
+        part_length = math.ceil(var_num / self.worker_num)
         assert part_length > 0
 
         start = 0


### PR DESCRIPTION
用 ceil 切分任务会比 floor 更合理一点（举个例子，14 个 job 分给 3 个 worker，取 floor 为 4,4,6, 取 ceil 为 5, 5, 4, 后者 workload 最大的那个 worker 的工作量会更小一些）
